### PR TITLE
Add relax mod replaying

### DIFF
--- a/libs/osu/core/src/gameplay/GameStateEvaluator.ts
+++ b/libs/osu/core/src/gameplay/GameStateEvaluator.ts
@@ -273,7 +273,7 @@ export class GameStateEvaluator {
         break;
       }
 
-      // If this hitobject is too early, then the other ones will be as well, so break.
+      // If this hitobject is too early for relax, then the other ones will be as well, so break.
       const delta = currentTime - hitCircle.hitTime;
       if (hasRelax && delta < -RELAX_LENIENCY) break;
 

--- a/libs/osu/core/src/mods/Mods.ts
+++ b/libs/osu/core/src/mods/Mods.ts
@@ -61,3 +61,6 @@ export const ModSettings: Record<OsuClassicMod, ModSetting> = {
   SPUN_OUT: { name: "Spun Out" },
   SUDDEN_DEATH: { name: "Sudden Death" },
 };
+
+// How early before a hitobject's time Relax can hit. (in ms)
+export const RELAX_LENIENCY = 12;


### PR DESCRIPTION
This adds the ability to watch relax mod replays in the app. Fixes #23.

I tested this on a few of my old replays, and it was sometimes off by a couple 100s or misses. The in-game replay viewer is often even worse, so I can't be sure why this happens. But it's pretty close anyways.

Thank you for making this awesome tool! 