### PR TITLE
Add an option to auto jump to end of replay

### DIFF
--- a/apps/desktop/frontend/src/app/components/analyzer/SettingsModal.tsx
+++ b/apps/desktop/frontend/src/app/components/analyzer/SettingsModal.tsx
@@ -198,6 +198,17 @@ function PlaybarSettingsSection() {
             }
             label={"Show difficulty graph"}
           />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={settings.jumpToEndOnLoad}
+                onChange={(event) =>
+                  playbarSettingsStore.changeSettings((s) => (s.jumpToEndOnLoad = event.target.checked))
+                }
+              />
+            }
+            label={"Jump to end of replay"}
+          />
         </FormGroup>
       </Stack>
     </Paper>

--- a/apps/desktop/frontend/src/app/services/common/playbar.ts
+++ b/apps/desktop/frontend/src/app/services/common/playbar.ts
@@ -4,16 +4,19 @@ import { JSONSchemaType } from "ajv";
 
 export interface PlaybarSettings {
   difficultyGraphEnabled: boolean;
+  jumpToEndOnLoad: boolean;
 }
 
 export const DEFAULT_PLAY_BAR_SETTINGS: PlaybarSettings = Object.freeze({
   difficultyGraphEnabled: true,
+  jumpToEndOnLoad: false,
 });
 
 export const PlaybarSettingsSchema: JSONSchemaType<PlaybarSettings> = {
   type: "object",
   properties: {
     difficultyGraphEnabled: { type: "boolean", default: DEFAULT_PLAY_BAR_SETTINGS.difficultyGraphEnabled },
+    jumpToEndOnLoad: { type: "boolean", default: DEFAULT_PLAY_BAR_SETTINGS.jumpToEndOnLoad },
   },
   required: [],
 };

--- a/apps/desktop/frontend/src/app/services/manager/ScenarioManager.ts
+++ b/apps/desktop/frontend/src/app/services/manager/ScenarioManager.ts
@@ -16,6 +16,7 @@ import { readFile } from "fs/promises";
 import { BlueprintLocatorService } from "../common/local/BlueprintLocatorService";
 import { OsuFolderService } from "../common/local/OsuFolderService";
 import { BeatmapBackgroundSettingsStore } from "../common/beatmap-background";
+import { PlaybarSettingsStore } from "../common/playbar";
 import { TextureManager } from "../textures/TextureManager";
 import { ReplayFileWatcher } from "../common/local/ReplayFileWatcher";
 import { ModSettingsService } from "../analysis/mod-settings";
@@ -44,6 +45,7 @@ export class ScenarioManager {
     private readonly textureManager: TextureManager,
     private readonly replayService: ReplayService,
     private readonly beatmapBackgroundSettingsStore: BeatmapBackgroundSettingsStore,
+    private readonly playbarSettingsStore: PlaybarSettingsStore,
     private readonly beatmapManager: BeatmapManager,
     private readonly replayManager: ReplayManager,
     private readonly sceneManager: AnalysisSceneManager,
@@ -103,6 +105,9 @@ export class ScenarioManager {
       const duration = (this.audioEngine.song?.mediaElement.duration ?? 0) * 1000;
       this.gameClock.setDuration(duration);
       this.gameSimulator.calculateDifficulties(rawBlueprint, duration, modsToBitmask(replay.mods));
+      if (this.playbarSettingsStore.getSettings().jumpToEndOnLoad) {
+        this.gameClock.seekTo(duration);
+      }
     });
 
     // If the building is too slow or unbearable, we should push the building to a WebWorker, but right now it's ok


### PR DESCRIPTION
Personally I use rewind to calibrate the offset, so I almost always go to the end of the replay to see global error stats.

It'd be nice if there is an option to automatically jump to end of replay when a new replay is found. That way I can just press F2 in game and look at the rewind window without alt-tab.