### PR TITLE
Use `float` for star rating instead of `double`

### DIFF
--- a/libs/osu-local/db-reader/src/DatabaseTypes.ts
+++ b/libs/osu-local/db-reader/src/DatabaseTypes.ts
@@ -14,7 +14,7 @@ type Single = number; // 32bit IEEE floating point value
 type Double = number; // 64bit IEEE floating point value
 
 // osu!.db specific
-type IntDoublePair = [Int, Double];
+type IntSinglePair = [Int, Single];
 export type TimingPoint = {
   bpm: Double;
   offset: Double;
@@ -53,7 +53,7 @@ enum GameplayMode {
 }
 
 // The first one will be the mods as a mask and the second one as the star rating
-export type StarRatings = IntDoublePair[];
+export type StarRatings = IntSinglePair[];
 
 export type Beatmap = {
   bytesOfBeatmapEntry: Int;

--- a/libs/osu-local/db-reader/src/OsuDBReader.ts
+++ b/libs/osu-local/db-reader/src/OsuDBReader.ts
@@ -13,8 +13,8 @@ export class OsuDBReader extends Reader {
     for (let i = 0; i < count; i++) {
       const b1 = this.readByte(); // === 0x08
       const mods = buffer.readInt32();
-      const b2 = buffer.readByte(); // === 0x0d
-      const stars = buffer.readDouble();
+      const b2 = buffer.readByte(); // === 0x0c
+      const stars = buffer.readFloat();
       if (mods !== undefined && stars !== undefined) list.push([mods, stars]);
     }
     return list;


### PR DESCRIPTION
Resolves https://github.com/abstrakt8/rewind/issues/108.

Reads star ratings as floats instead of doubles as it was changed in the latest database version. Ref: https://github.com/ppy/osu/wiki/Legacy-database-file-structure